### PR TITLE
remove raw_pointer_derive lint

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -113,7 +113,6 @@ impl<'d> fmt::Debug for Document<'d> {
 macro_rules! node(
     ($name:ident, $raw:ty, $doc:expr) => (
         #[doc = $doc]
-        #[allow(raw_pointer_derive)]
         #[derive(Copy,Clone)]
         pub struct $name<'d> {
             document: Document<'d>,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -91,7 +91,6 @@ impl ProcessingInstruction {
     pub fn value(&self) -> Option<&str> { self.value.map(|v| v.as_slice()) }
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(Debug,Copy,Clone,PartialEq)]
 pub enum ChildOfRoot {
     Element(*mut Element),
@@ -127,7 +126,6 @@ impl ChildOfRoot {
     }
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(Debug,Copy,Clone,PartialEq)]
 pub enum ChildOfElement {
     Element(*mut Element),
@@ -184,7 +182,6 @@ impl ChildOfElement {
     }
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(Debug,Copy,Clone,PartialEq)]
 pub enum ParentOfChild {
     Root(*mut Root),

--- a/src/string_pool.rs
+++ b/src/string_pool.rs
@@ -55,7 +55,6 @@ impl Drop for Chunk {
     }
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(Copy,Clone)]
 pub struct InternedString {
     data: *const u8,

--- a/src/thindom.rs
+++ b/src/thindom.rs
@@ -237,7 +237,6 @@ impl<'d> Iterator for Siblings<'d> {
 
 macro_rules! node(
     ($name:ident, $raw:ty) => (
-        #[allow(raw_pointer_derive)]
         #[derive(Copy,Clone)]
         pub struct $name<'d> {
             node: *mut $raw,


### PR DESCRIPTION
The raw_pointer_deriving lint has been removed from rust: rust-lang/rust#14615
(and re-added as a no-op in 30346). This causes warnings during compile. 
removing them fixes these warnings

(I don't know how what happens if someone uses an older version of rust to compile this)