### PR TITLE
Understand the "xml" namespace prefix when parsing into the DOM

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@ pub mod writer;
 
 pub use str::XmlChar;
 
+static XML_NS_PREFIX: &'static str = "xml";
+static XML_NS_URI:    &'static str = "http://www.w3.org/XML/1998/namespace";
+
 /// A prefixed name. This represents what is found in the string form
 /// of an XML document, and does not apply any namespace mapping.
 #[derive(Debug,Copy,Clone,PartialEq,Eq,PartialOrd,Ord)]

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -6,9 +6,6 @@ use string_pool::{StringPool,InternedString};
 use std::marker::PhantomData;
 use std::slice;
 
-static XML_NS_PREFIX: &'static str = "xml";
-static XML_NS_URI:    &'static str = "http://www.w3.org/XML/1998/namespace";
-
 struct InternedQName {
     namespace_uri: Option<InternedString>,
     local_part: InternedString,
@@ -644,7 +641,7 @@ impl Connections {
     {
         let mut namespaces = Vec::new();
 
-        namespaces.push((XML_NS_PREFIX, XML_NS_URI));
+        namespaces.push((::XML_NS_PREFIX, ::XML_NS_URI));
 
         let all_namespaces =
             self.element_parents(element)


### PR DESCRIPTION
This does not yet *do* anything with the attributes; it only stops
them from preventing a successful parse.

Related to #46