### PR TITLE
Fix DTD parsing issue resulting in `ExpectedClosingQuote` error.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -481,8 +481,10 @@ fn parse_external_id<'a>(pm: &mut XmlMaster<'a>, xml: StringPoint<'a>)
     let (xml, _) = try_parse!(xml.expect_literal("SYSTEM"));
     let (xml, _) = try_parse!(xml.expect_space());
     let (xml, external_id) = try_parse!(
-        parse_quoted_value(pm, xml, |_, xml, _| xml.consume_name().map_err(|_| SpecificError::ExpectedSystemLiteral))
-        );
+        parse_quoted_value(pm, xml, |_, xml, quote|
+            xml.consume_attribute_value(quote).map_err(|_| SpecificError::ExpectedSystemLiteral)
+        )
+    );
 
     success(external_id, xml)
 }
@@ -1311,7 +1313,9 @@ mod test {
 
     #[test]
     fn a_prolog_with_a_document_type_declaration() {
-        let package = quick_parse("<?xml version='1.0'?><!DOCTYPE doc SYSTEM \"doc.dtd\"><hello/>");
+        let package = quick_parse(r#"<?xml version='1.0'?>
+        <!DOCTYPE doc SYSTEM "http://example.com/doc.dtd">
+        <hello/>"#);
         let doc = package.as_document();
         let top = top(&doc);
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -49,6 +49,8 @@ pub trait XmlStr {
     /// Find the end of the starting tag
     fn end_of_start_tag(&self) -> Option<usize>;
     fn end_of_encoding(&self) -> Option<usize>;
+    /// Find the end of the internal doc type declaration, not including the ]
+    fn end_of_int_subset(&self) -> Option<usize>;
 }
 
 impl<'a> XmlStr for &'a str {
@@ -143,6 +145,8 @@ impl<'a> XmlStr for &'a str {
     fn end_of_encoding(&self) -> Option<usize> {
         self.end_of_start_rest(|c| c.is_encoding_start_char(), |c| c.is_encoding_rest_char())
     }
+
+    fn end_of_int_subset(&self) -> Option<usize> { self.find("]") }
 }
 
 /// Predicates used when parsing an characters in an XML document.
@@ -296,5 +300,10 @@ mod test {
     #[test]
     fn end_of_char_data_includes_multiple_right_squares() {
         assert_eq!("hello]]world".end_of_char_data(), Some("hello]]world".len()));
+    }
+
+    #[test]
+    fn end_of_int_subset_excludes_right_square() {
+        assert_eq!("hello]>world".end_of_int_subset(), Some("hello".len()))
     }
 }


### PR DESCRIPTION
Certain characters (such as `/`) in the document type declaration (dtd)
could cause the parser to fail.
This updates `sxd_document::parser::parse_external_id()` to use a
slightly different (more permissive) function to consume the attribute
string.

refs #50, #59