### PR TITLE
Add an API to get prefixes registered directly on an element

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -262,6 +262,12 @@ impl<'d> Element<'d> {
         )
     }
 
+    /// View all the namespaces that are registered on this element, without
+    /// walking up the tree.
+    pub fn registered_namespaces(&self) -> Vec<Namespace<'d>> {
+        unimplemented!();
+    }
+
     /// Retrieve all namespaces that are in scope, recursively walking
     /// up the document tree.
     pub fn namespaces_in_scope(&self) -> Vec<Namespace<'d>> {
@@ -1058,6 +1064,49 @@ mod test {
         assert_eq!(2, nses.len());
 
         let ns = nses.iter().find(|ns| ns.prefix() == "prefix").unwrap();
+        assert_eq!("uri2", ns.uri());
+    }
+
+    #[test]
+    fn elements_get_multiple_registered_namespaces() {
+        let package = Package::new();
+        let doc = package.as_document();
+
+        let element = doc.create_element("alpha");
+        element.register_prefix("a", "uria");
+        element.register_prefix("b", "urib");
+        element.register_prefix("c", "uric");
+
+        let nses = element.registered_namespaces();
+        assert_eq!(3, nses.len());
+
+        let a_ns = nses.iter().find(|ns| ns.prefix() == "a").unwrap();
+        assert_eq!("uria", a_ns.uri());
+
+        let b_ns = nses.iter().find(|ns| ns.prefix() == "b").unwrap();
+        assert_eq!("urib", b_ns.uri());
+
+        let b_ns = nses.iter().find(|ns| ns.prefix() == "b").unwrap();
+        assert_eq!("urib", b_ns.uri());
+    }
+
+    #[test]
+    fn elements_get_only_own_registered_namespace() {
+        let package = Package::new();
+        let doc = package.as_document();
+
+        let parent = doc.create_element("parent");
+        parent.register_prefix("parentprefix", "uri1");
+
+        let child = doc.create_element("child");
+        child.register_prefix("ownprefix", "uri2");
+
+        parent.append_child(child);
+
+        let nses = child.registered_namespaces();
+        assert_eq!(1, nses.len());
+
+        let ns = nses.iter().find(|ns| ns.prefix() == "ownprefix").unwrap();
         assert_eq!("uri2", ns.uri());
     }
 

--- a/src/dom.rs
+++ b/src/dom.rs
@@ -264,8 +264,9 @@ impl<'d> Element<'d> {
 
     /// View all the namespaces that are registered on this element, without
     /// walking up the tree.
-    pub fn registered_namespaces(&self) -> Vec<Namespace<'d>> {
-        unimplemented!();
+    pub fn registered_namespaces(&self) -> impl Iterator<Item=Namespace<'d>> {
+        self.document.connections.element_registered_namespaces(self.node)
+            .map(|(prefix, uri)| Namespace { prefix, uri })
     }
 
     /// Retrieve all namespaces that are in scope, recursively walking
@@ -671,7 +672,7 @@ impl<'d> From<ChildOfRoot<'d>> for ChildOfElement<'d> {
 #[cfg(test)]
 mod test {
     use super::super::{Package,QName};
-    use super::{ChildOfRoot,ChildOfElement,ParentOfChild};
+    use super::{ChildOfRoot,ChildOfElement,ParentOfChild,Namespace};
 
     macro_rules! assert_qname_eq(
         ($l:expr, $r:expr) => (assert_eq!(Into::<QName>::into($l), $r.into()));
@@ -1077,7 +1078,7 @@ mod test {
         element.register_prefix("b", "urib");
         element.register_prefix("c", "uric");
 
-        let nses = element.registered_namespaces();
+        let nses: Vec<Namespace> = element.registered_namespaces().collect();
         assert_eq!(3, nses.len());
 
         let a_ns = nses.iter().find(|ns| ns.prefix() == "a").unwrap();
@@ -1103,7 +1104,7 @@ mod test {
 
         parent.append_child(child);
 
-        let nses = child.registered_namespaces();
+        let nses: Vec<Namespace> = child.registered_namespaces().collect();
         assert_eq!(1, nses.len());
 
         let ns = nses.iter().find(|ns| ns.prefix() == "ownprefix").unwrap();

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -771,6 +771,14 @@ impl Connections {
         None
     }
 
+    pub fn element_registered_namespaces(&self, element: *mut Element)
+        -> impl Iterator<Item=(&str, &str)>
+    {
+        let element_ref = unsafe { &*element };
+
+        element_ref.prefix_to_namespace.iter().map(|(p, n)| (p.as_slice(), n.as_slice()))
+    }
+
     pub fn element_namespaces_in_scope(&self, element: *mut Element)
                                        -> NamespacesInScope
     {


### PR DESCRIPTION
This PR is the beginning of a resolution of #72. It adds an API to fetch the namespace registrations for a single element, a different feature from the existing APIs that go back through everything in scope.

This API is different from other similar APIs because it returns an `impl Iterator` rather than a `Vec`. I like this method because it lets the consumer decide whether or not the iterator needs to be collected, but it is a different approach. I'm very open to modifying this to return a `Vec` instead (which would be an easy change).

Future work:
- Add an API to remove prefix registrations
- Integrate this into the `writer` module