### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/str.rs
+++ b/src/str.rs
@@ -178,21 +178,21 @@ impl XmlChar for char {
 
     fn is_ncname_start_char(self) -> bool {
         match self {
-            'A'...'Z'                   |
+            'A'..='Z'                   |
             '_'                         |
-            'a'...'z'                   |
-            '\u{0000C0}'...'\u{0000D6}' |
-            '\u{0000D8}'...'\u{0000F6}' |
-            '\u{0000F8}'...'\u{0002FF}' |
-            '\u{000370}'...'\u{00037D}' |
-            '\u{00037F}'...'\u{001FFF}' |
-            '\u{00200C}'...'\u{00200D}' |
-            '\u{002070}'...'\u{00218F}' |
-            '\u{002C00}'...'\u{002FEF}' |
-            '\u{003001}'...'\u{00D7FF}' |
-            '\u{00F900}'...'\u{00FDCF}' |
-            '\u{00FDF0}'...'\u{00FFFD}' |
-            '\u{010000}'...'\u{0EFFFF}' => true,
+            'a'..='z'                   |
+            '\u{0000C0}'..='\u{0000D6}' |
+            '\u{0000D8}'..='\u{0000F6}' |
+            '\u{0000F8}'..='\u{0002FF}' |
+            '\u{000370}'..='\u{00037D}' |
+            '\u{00037F}'..='\u{001FFF}' |
+            '\u{00200C}'..='\u{00200D}' |
+            '\u{002070}'..='\u{00218F}' |
+            '\u{002C00}'..='\u{002FEF}' |
+            '\u{003001}'..='\u{00D7FF}' |
+            '\u{00F900}'..='\u{00FDCF}' |
+            '\u{00FDF0}'..='\u{00FFFD}' |
+            '\u{010000}'..='\u{0EFFFF}' => true,
             _ => false,
         }
     }
@@ -202,10 +202,10 @@ impl XmlChar for char {
         match self {
             '-'                     |
             '.'                     |
-            '0'...'9'               |
+            '0'..='9'               |
             '\u{00B7}'              |
-            '\u{0300}'...'\u{036F}' |
-            '\u{203F}'...'\u{2040}' => true,
+            '\u{0300}'..='\u{036F}' |
+            '\u{203F}'..='\u{2040}' => true,
             _ => false
         }
     }
@@ -222,33 +222,33 @@ impl XmlChar for char {
 
     fn is_decimal_char(self) -> bool {
         match self {
-            '0'...'9' => true,
+            '0'..='9' => true,
             _ => false,
         }
     }
 
     fn is_hex_char(self) -> bool {
         match self {
-            '0'...'9' |
-            'a'...'f' |
-            'A'...'F' => true,
+            '0'..='9' |
+            'a'..='f' |
+            'A'..='F' => true,
             _ => false,
         }
     }
 
     fn is_encoding_start_char(self) -> bool {
         match self {
-            'A'...'Z' |
-            'a'...'z' => true,
+            'A'..='Z' |
+            'a'..='z' => true,
             _ => false,
         }
     }
 
     fn is_encoding_rest_char(self) -> bool {
         match self {
-            'A'...'Z' |
-            'a'...'z' |
-            '0'...'9' |
+            'A'..='Z' |
+            'a'..='z' |
+            '0'..='9' |
             '.' |
             '_' |
             '-' => true,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -349,8 +349,8 @@ impl Writer {
                     // No need to do anything
                 },
                 NamespaceType::Prefix(prefix) => {
-                    try!(writer.write_str(prefix));
-                    try!(writer.write_str(":"));
+                    writer.write_str(prefix)?;
+                    writer.write_str(":")?;
                 },
                 NamespaceType::Unknown => {
                     panic!("No namespace prefix available for {}", namespace_uri);
@@ -365,12 +365,12 @@ impl Writer {
     {
         for item in value.split_keeping_delimiter(|c| c == '<' || c == '>' || c == '&' || c == '\'' || c == '"') {
             match item {
-                SplitType::Match(t)        => try!(writer.write_str(t)),
-                SplitType::Delimiter("<")  => try!(writer.write_str("&lt;")),
-                SplitType::Delimiter(">")  => try!(writer.write_str("&gt;")),
-                SplitType::Delimiter("&")  => try!(writer.write_str("&amp;")),
-                SplitType::Delimiter("'")  => try!(writer.write_str("&apos;")),
-                SplitType::Delimiter("\"") => try!(writer.write_str("&quot;")),
+                SplitType::Match(t)        => writer.write_str(t)?,
+                SplitType::Delimiter("<")  => writer.write_str("&lt;")?,
+                SplitType::Delimiter(">")  => writer.write_str("&gt;")?,
+                SplitType::Delimiter("&")  => writer.write_str("&amp;")?,
+                SplitType::Delimiter("'")  => writer.write_str("&apos;")?,
+                SplitType::Delimiter("\"") => writer.write_str("&quot;")?,
                 SplitType::Delimiter(..)   => unreachable!(),
             }
         }
@@ -389,37 +389,37 @@ impl Writer {
 
         mapping.populate_scope(&element, &attrs);
 
-        try!(writer.write_str("<"));
-        try!(self.format_qname(element.name(), mapping, element.preferred_prefix(), false, writer));
+        writer.write_str("<")?;
+        self.format_qname(element.name(), mapping, element.preferred_prefix(), false, writer)?;
 
         for attr in &attrs {
-            try!(writer.write_str(" "));
-            try!(self.format_qname(attr.name(), mapping, attr.preferred_prefix(), true, writer));
-            try!(write!(writer, "="));
-            try!(write!(writer, "{}", self.quote_char()));
-            try!(self.format_attribute_value(attr.value(), writer));
-            try!(write!(writer, "{}", self.quote_char()));
+            writer.write_str(" ")?;
+            self.format_qname(attr.name(), mapping, attr.preferred_prefix(), true, writer)?;
+            write!(writer, "=")?;
+            write!(writer, "{}", self.quote_char())?;
+            self.format_attribute_value(attr.value(), writer)?;
+            write!(writer, "{}", self.quote_char())?;
         }
 
         if let Some(ns_uri) = mapping.default_namespace_uri_in_current_scope() {
-            try!(writer.write_str(" xmlns='"));
-            try!(writer.write_str(ns_uri));
-            try!(writer.write_str("'"));
+            writer.write_str(" xmlns='")?;
+            writer.write_str(ns_uri)?;
+            writer.write_str("'")?;
         }
 
         for &(ref prefix, ref ns_uri) in mapping.prefixes_in_current_scope() {
-            try!(writer.write_str(" xmlns:"));
-            try!(writer.write_str(prefix));
-            try!(write!(writer, "='{}'", ns_uri));
+            writer.write_str(" xmlns:")?;
+            writer.write_str(prefix)?;
+            write!(writer, "='{}'", ns_uri)?;
         }
 
         let mut children = element.children();
         if children.is_empty() {
-            try!(writer.write_str("/>"));
+            writer.write_str("/>")?;
             mapping.pop_scope();
             Ok(())
         } else {
-            try!(writer.write_str(">"));
+            writer.write_str(">")?;
 
             todo.push(ElementEnd(element));
             children.reverse();
@@ -442,8 +442,8 @@ impl Writer {
                                          -> io::Result<()>
         where W: Write
     {
-        try!(writer.write_str("</"));
-        try!(self.format_qname(element.name(), mapping, element.preferred_prefix(), false, writer));
+        writer.write_str("</")?;
+        self.format_qname(element.name(), mapping, element.preferred_prefix(), false, writer)?;
         writer.write_str(">")
     }
 
@@ -452,10 +452,10 @@ impl Writer {
     {
         for item in text.text().split_keeping_delimiter(|c| c == '<' || c == '>' || c == '&') {
             match item {
-                SplitType::Match(t)       => try!(writer.write_str(t)),
-                SplitType::Delimiter("<") => try!(writer.write_str("&lt;")),
-                SplitType::Delimiter(">") => try!(writer.write_str("&gt;")),
-                SplitType::Delimiter("&") => try!(writer.write_str("&amp;")),
+                SplitType::Match(t)       => writer.write_str(t)?,
+                SplitType::Delimiter("<") => writer.write_str("&lt;")?,
+                SplitType::Delimiter(">") => writer.write_str("&gt;")?,
+                SplitType::Delimiter("&") => writer.write_str("&amp;")?,
                 SplitType::Delimiter(..)  => unreachable!(),
             }
         }
@@ -509,7 +509,7 @@ impl Writer {
         let mut mapping = PrefixMapping::new();
 
         while ! todo.is_empty() {
-            try!(self.format_one(todo.pop().unwrap(), &mut todo, &mut mapping, writer));
+            self.format_one(todo.pop().unwrap(), &mut todo, &mut mapping, writer)?;
         }
 
         Ok(())
@@ -518,13 +518,13 @@ impl Writer {
     fn format_declaration<'d, W: ?Sized>(&self, writer: &mut W) -> io::Result<()>
         where W: Write
     {
-        try!(write!(writer, "<?xml version={}1.0{}", self.quote_char(), self.quote_char()));
+        write!(writer, "<?xml version={}1.0{}", self.quote_char(), self.quote_char())?;
 
         if self.write_encoding {
-            try!(write!(writer, " encoding={}UTF-8{}", self.quote_char(), self.quote_char()));
+            write!(writer, " encoding={}UTF-8{}", self.quote_char(), self.quote_char())?;
         }
 
-        try!(write!(writer, "?>"));
+        write!(writer, "?>")?;
 
         Ok(())
     }
@@ -533,14 +533,14 @@ impl Writer {
     pub fn format_document<'d, W: ?Sized>(&self, doc: &'d dom::Document<'d>, writer: &mut W) -> io::Result<()>
         where W: Write
     {
-        try!(self.format_declaration(writer));
+        self.format_declaration(writer)?;
 
         for child in doc.root().children().into_iter() {
-            try!(match child {
+            match child {
                 ChildOfRoot::Element(e) => self.format_body(e, writer),
                 ChildOfRoot::Comment(c) => self.format_comment(c, writer),
                 ChildOfRoot::ProcessingInstruction(p) => self.format_processing_instruction(p, writer),
-            })
+            }?
         }
 
         Ok(())


### PR DESCRIPTION
This fixes the deprecation warnings.

- rustc 1.38+ complains about
  `warning: ... range patterns are deprecated`
- rustc 1.40 nightly complains about
  `warning: use of deprecated item 'try': use the ? operator instead`
