### PR TITLE
string_pool.rs: Fix UB

### DIFF
--- a/src/string_pool.rs
+++ b/src/string_pool.rs
@@ -47,7 +47,7 @@ impl Drop for Chunk {
         // have a destructor. This means the len doesn't matter, only
         // the capacity.
         unsafe {
-            Vec::from_raw_parts(self.start, self.capacity, self.capacity);
+            Vec::from_raw_parts(self.start, 0, self.capacity);
         }
     }
 }


### PR DESCRIPTION
`from_raw_parts` requires the first `length` values to be initialized but here we're not initializing any (likely doesn't matter for u8).

I'm guessing the whole file can be rewritten in a much nicer way with modern Rust (probably vectors are not needed to allocate a fixed chunk of memory?)